### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -7,6 +7,11 @@ on:
       - "main"
       - "master"
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   },
   "author": "Balena Inc. <hello@balena.io>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/balena-io-modules/pinejs-webresource-cloudfront.git"
+  },
   "engines": {
     "node": ">=20.14.0",
     "npm": ">=10.7.0"


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch